### PR TITLE
Add Gruntfile to generate HTML as JS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ ansible.log
 ansible/.gogitit-cache.yml
 ansible/vars/zz_custom_vars.yml
 
+node_modules/*
+

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,0 +1,33 @@
+module.exports = function(grunt) {
+  grunt.initConfig({
+    buildEnv: grunt.option('env'),
+    ngtemplates: {
+      dist: {
+	src: [(function() {
+	  var buildEnv = grunt.option('env')
+	  var src = ['ui/**/*.html', buildEnv+'/**/*.html']
+	  if(buildEnv == 'paid') {
+	    src.push('notifications/**/*.html')
+	  }
+	  return src
+	}())],
+	dest: '<%= buildEnv %>/ui/assets/extensions/templates.js',
+	options: {
+	  url: function(file) {
+	    var buildEnv = grunt.option('env')
+	    file = file.replace(buildEnv+'/', '');
+	    file = file.replace('notifications/', '');
+	    file = file.replace('assets/extensions', 'custom-templates');
+	    return file
+          },
+	  prefix: 'online/',
+          module: 'openshiftOnlineConsoleTemplates',
+          standalone: true
+        }
+      }
+    }
+  })
+
+  grunt.loadNpmTasks('grunt-angular-templates');
+  grunt.registerTask('build', ['ngtemplates']);
+}

--- a/README.md
+++ b/README.md
@@ -9,4 +9,10 @@ These files are built and deployed in an Apache HTTP Server container. This can 
 
 If you run `oc expose svc/online-console-extensions` you will be able to see the files in a web browser under `<route>/ui`
 
+## Building HTML templates
 
+To serve HTML templates without requiring CORS headers, they are converted into Javascript which is then included as a dependency to our main online extensions module, injecting the HTML into the pages. To generate the Javascript, (for example, after you've made a change to an HTML template) ensure that Grunt is installed (`sudo npm install`) and run:
+
+`grunt build --env=<free/paid/dedicated/notifications>`
+
+which will generate the file under `<env>/ui/assets/extensions/templates.js`. This file needs to be included as an `extensionScript` in the openshift-web-console project.

--- a/ansible/README.md
+++ b/ansible/README.md
@@ -41,16 +41,21 @@ Here's an example for how to set stylesheet/scripts urls:
 ```
 ( when osod_cluster_tier == "pro" )
 - set_fact:
-    openshift_extension_script_urls: "[ 'https://{{ oso_ext_appname }}-{{ oso_ext_namespace }}.{{ hostvars[groups['OSEv3'][0]].openshift_master_default_subdomain }}/ui/assets/extensions/online-extensions.js', 'https://{{ oso_ext_appname }}-{{ oso_ext_namespace }}.{{ hostvars[groups['OSEv3'][0]].openshift_master_default_subdomain }}/ui/assets/extensions/intercom-widget-extension.js', 'https://{{ oso_ext_appname }}-{{ oso_ext_namespace }}.{{ openshift_master_default_subdomain }}/ui/assets/extensions/online-notifications.js' ]"
+    openshift_extension_script_urls:
+      - "https://{{ oso_ext_appname }}-{{ oso_ext_namespace }}.{{ hostvars[groups['OSEv3'][0]].openshift_master_default_subdomain }}/ui/assets/extensions/online-extensions.js"
+      - "https://{{ oso_ext_appname }}-{{ oso_ext_namespace }}.{{ hostvars[groups['OSEv3'][0]].openshift_master_default_subdomain }}/ui/assets/extensions/intercom-widget-extension.js"
+      - "https://{{ oso_ext_appname }}-{{ oso_ext_namespace }}.{{ openshift_master_default_subdomain }}/ui/assets/extensions/online-notifications.js"
 
 ( when osod_cluster_tier == "starter"|"ipaas"|"osio" )
 - set_fact:
-    openshift_extension_script_urls: "[ 'https://{{ oso_ext_appname }}-{{ oso_ext_namespace }}.{{ hostvars[groups['OSEv3'][0]].openshift_master_default_subdomain }}/assets/extensions/online-extensions.js' ]"
+    openshift_extension_script_urls:
+      - "https://{{ oso_ext_appname }}-{{ oso_ext_namespace }}.{{ hostvars[groups['OSEv3'][0]].openshift_master_default_subdomain }}/assets/extensions/online-extensions.js"
   when: tier == "starter"
 
 ( same for all osod_cluster_tier )
 - set_fact:
-    openshift_extension_stylesheet_urls: "[ 'https://{{ oso_ext_appname }}-{{ oso_ext_namespace }}.{{ hostvars[groups['OSEv3'][0]].openshift_master_default_subdomain }}/assets/extensions/online-extensions.css']"
+    openshift_extension_stylesheet_urls:
+      - "https://{{ oso_ext_appname }}-{{ oso_ext_namespace }}.{{ hostvars[groups['OSEv3'][0]].openshift_master_default_subdomain }}/assets/extensions/online-extensions.css"
 
 ```
 

--- a/free/ui/assets/extensions/templates.js
+++ b/free/ui/assets/extensions/templates.js
@@ -1,0 +1,47 @@
+angular.module('openshiftOnlineConsoleTemplates', []).run(['$templateCache', function($templateCache) {
+  'use strict';
+
+  $templateCache.put('online/ui/custom-templates/about.html',
+    "<div class=\"middle surface-shaded\">\n" +
+    "  <div class=\"middle-content\">\n" +
+    "    <div class=\"container gutter-top\">\n" +
+    "      <div class=\"row\">\n" +
+    "        <div class=\"col-md-12\">\n" +
+    "          <div class=\"about\">\n" +
+    "            <div class=\"row\">\n" +
+    "              <div class=\"col-md-2 about-icon gutter-top hidden-sm hidden-xs\">\n" +
+    "                <img src=\"images/openshift-logo.svg\" />\n" +
+    "              </div>\n" +
+    "              <div class=\"col-md-9\">\n" +
+    "                <h1>Red Hat OpenShift <span class=\"about-reg\">&reg;</span></h1>\n" +
+    "                <h2>About</h2>\n" +
+    "                <p><a target=\"_blank\" href=\"https://openshift.com\">OpenShift</a> is Red Hat's Platform-as-a-Service (PaaS) that allows developers to quickly develop, host, and scale applications in a cloud environment.</p>\n" +
+    "\n" +
+    "                <h2 id=\"version\">Version</h2>\n" +
+    "                <dl class=\"dl-horizontal left\">\n" +
+    "                  <dt>OpenShift Master:</dt>\n" +
+    "                  <dd>{{version.master.openshift || 'unknown'}}</dd>\n" +
+    "                  <dt>Kubernetes Master:</dt>\n" +
+    "                  <dd>{{version.master.kubernetes || 'unknown'}}</dd>\n" +
+    "                </dl>\n" +
+    "\n" +
+    "                <h2>Registry</h2>\n" +
+    "                <p>\n" +
+    "                  You can push images to and pull images from the registry via:\n" +
+    "                  <copy-to-clipboard display-wide=\"true\" clipboard-text=\"online_registry_url\" input-text=\"online_registry_url\" class=\"ng-isolate-scope\"></copy-to-clipboard>\n" +
+    "                </p>\n" +
+    "\n" +
+    "                <p>The <a target=\"_blank\" href=\"{{'welcome' | helpLink}}\">documentation</a> contains information and guides to help you learn about OpenShift and start exploring its features. From getting started with creating your first application, to trying out more advanced build and deployment techniques, it provides what you need to set up and manage your OpenShift environment as an application developer.</p>\n" +
+    "\n" +
+    "                <p>With the OpenShift command line interface (CLI), you can create applications and manage OpenShift projects from a terminal. To get started using the CLI, visit <a href=\"command-line\">Command Line Tools</a>.</p>\n" +
+    "              </div>\n" +
+    "            </div>\n" +
+    "          </div>\n" +
+    "        </div>\n" +
+    "      </div><!-- /row -->\n" +
+    "    </div><!-- /container -->\n" +
+    "  </div><!-- /middle-content -->\n" +
+    "</div><!-- /middle -->\n"
+  );
+
+}]);

--- a/notifications/ui/assets/extensions/online-notifications.html
+++ b/notifications/ui/assets/extensions/online-notifications.html
@@ -1,0 +1,69 @@
+<project-header class="top-header"></project-header>
+<project-page class="online-notifications">
+  <!-- Middle section -->
+  <div class="middle-section">
+    <div class="middle-container">
+      <div class="middle-header">
+        <div class="container-fluid">
+          <div class="page-header">
+            <h1>
+              Notifications
+              <span class="page-header-link page-header-bleed-right">
+                <a ng-href="{{'notifications' | helpLink}}" target="_blank">
+                  Learn More <i class="fa fa-external-link" aria-hidden="true"></i>
+                </a>
+              </span>
+            </h1>
+          </div>
+        </div>
+      </div><!-- /middle-header-->
+      <div class="middle-content">
+        <div class="container-fluid">
+          <div class="row">
+            <div class="col-md-10 col-lg-8">
+              <p>Control which critical event email notifications to receive from OpenShift Online.</p>
+              <alerts alerts="alerts"></alerts>
+              <p>Email notifications for project <strong>{{projectName}}</strong> will be sent to <strong>{{requester}}</strong></p>
+            </div>
+          </div>
+          <div class="row">
+            <div class="col-md-10 col-lg-8">
+              <form name="forms.notifications">
+                <fieldset ng-disabled="disableInputs">
+                  <div class="form-group">
+                    <h4>Send notifications about critical events related to:</h4>
+                    <div class="checkbox">
+                      <label>
+                        <input ng-model="updatedPrefs.deployments" ng-true-value="'true'" ng-false-value="'false'" type="checkbox" autocomplete="off">
+                        Application deployments
+                      </label>
+                      <div style="padding-left: 20px">Example: Requesting more replicas than your quota allows.</div>
+                    </div>
+                    <div class="checkbox">
+                      <label>
+                        <input ng-model="updatedPrefs.builds" ng-true-value="'true'" ng-false-value="'false'" type="checkbox" autocomplete="off">
+                        Builds
+                      </label>
+                      <div style="padding-left: 20px">Example: An automatically-triggered build fails, no notifications sent for repeat failures.</div>
+                    </div>
+                    <div class="checkbox">
+                      <label>
+                        <input ng-model="updatedPrefs.storage" ng-true-value="'true'" ng-false-value="'false'" type="checkbox" autocomplete="off">
+                        Storage and persistent volumes
+                      </label>
+                      <div style="padding-left: 20px">Example: Unable to find a volume that satisfies the constraints defined in your persistent volume claim (PVC).</div>
+                    </div>
+                  </div>
+                  <div class="button-group gutter-top gutter-bottom">
+                    <button type="submit" class="btn btn-default" ng-click="save()" ng-disabled="forms.notifications.$invalid || forms.notifications.$pristine || disableInputs" value="">Save</button>
+                    <a ng-if="!forms.notifications.$pristine" href="" ng-click="reset()" class="mar-left-sm" style="vertical-align: -2px">Clear changes</a>
+                  </div>
+                </fieldset>
+              </form>
+            </div><!-- /col-* -->
+          </div>
+        </div>
+      </div><!-- /middle-content -->
+    </div><!-- /middle-container -->
+  </div><!-- /middle-section -->
+</project-page>

--- a/notifications/ui/assets/extensions/online-notifications.js
+++ b/notifications/ui/assets/extensions/online-notifications.js
@@ -1,0 +1,153 @@
+(function() {
+  'use strict';
+
+  // Add a Notifications submenu under Monitoring
+  var monitoringMenu = _.find(window.OPENSHIFT_CONSTANTS.PROJECT_NAVIGATION, { label: 'Monitoring' });
+  monitoringMenu.secondaryNavSections = [{
+    items: [{
+      href: monitoringMenu.href,
+      label: "Monitoring and Events"
+    }, {
+      href: "/online/notifications",
+      label: "Notifications"
+    }]
+  }];
+  delete monitoringMenu.href;
+
+  angular
+    .module('onlineNotificationExtensions', ['openshiftConsole', 'openshiftOnlineConsoleTemplates'])
+    .controller('OnlineNotificationController', function ($routeParams,
+                                                          $location,
+                                                          $scope,
+                                                          $filter,
+                                                          DataService,
+                                                          ProjectsService) {
+
+      var NOTIFICATION_CONFIG_MAP_NAME = 'openshift-online-notifications';
+
+      $scope.projectName = $routeParams.project;
+      $scope.alerts = $scope.alerts || {};
+      $scope.renderOptions = $scope.renderOptions || {};
+      $scope.disableInputs = false;
+
+      $scope.forms = $scope.forms || {};
+
+      $scope.config = {
+        apiVersion: "v1",
+        kind: "ConfigMap",
+        metadata: {
+          name: NOTIFICATION_CONFIG_MAP_NAME
+        },
+        data: {
+          deployments: 'false',
+          builds: 'false',
+          storage: 'false'
+        }
+      };
+      $scope.updatedPrefs = {};
+
+      $scope.reset = function () {
+        $scope.updatedPrefs = angular.copy($scope.config.data);
+
+        var form = $scope.forms.notifications;
+        form.$setPristine();
+        form.$setUntouched();
+      };
+
+      ProjectsService
+        .get($routeParams.project)
+        .then(_.spread(function (project, context) {
+          $scope.project = project;
+          $scope.requester = project.metadata.annotations['openshift.io/requester'];
+
+          $scope.save = function () {
+            var _handleSuccess = function (resource) {
+              $scope.config = angular.copy(resource);
+              $scope.reset();
+
+              $scope.alerts['onlineNotificationPreferences'] = {
+                type: "success",
+                message: "Successfully saved notification preferences."
+              }
+              $scope.disableInputs = false;
+            };
+
+            var _handleFailure = function (error) {
+              var details = $filter('getErrorDetails')(error);
+              if (details) {
+                details = "Reason: " + details;
+              }
+              $scope.alerts['onlineNotificationPreferences'] = {
+                type: "error",
+                message: "Failed to save notification preferences.",
+                details: details
+              };
+              $scope.disableInputs = false;
+            }
+
+            var config = angular.copy($scope.config);
+            // If a key is not provided in the form submit data, set it to false
+            // This ensures that invalid values are overwritten with either "true" or "false" upon save
+            config.data.deployments = ($scope.updatedPrefs.deployments && $scope.updatedPrefs.deployments === "true") ? $scope.updatedPrefs.deployments : "false";
+            config.data.builds = ($scope.updatedPrefs.builds && $scope.updatedPrefs.builds === "true") ? $scope.updatedPrefs.builds : "false";
+            config.data.storage = ($scope.updatedPrefs.storage && $scope.updatedPrefs.storage === "true") ? $scope.updatedPrefs.storage : "false";
+            $scope.disableInputs = true;
+
+            // If there's no resource version, the config hasn't been persisted
+            if (!config.metadata.resourceVersion) {
+              DataService
+                .create("configmaps", null, config, context)
+                .then(_handleSuccess, _handleFailure);
+            } else {
+              DataService
+                .update("configmaps", NOTIFICATION_CONFIG_MAP_NAME, config, context)
+                .then(_handleSuccess, _handleFailure);
+            }
+          };
+
+          DataService
+            .get("configmaps", NOTIFICATION_CONFIG_MAP_NAME, context, {
+              errorNotification: false
+            })
+            .then(function (resource) {
+              // Validate all keys are set by us, or alert otherwise
+              _.forEach(resource.data, function(value, key) {
+                if (key !== "deployments" && key !== "builds" && key !== "storage") {
+                  $scope.alerts['onlineNotificationPreferences'] = {
+                    type: "warning",
+                    message: "Notification preferences contain an unknown type.",
+                    details: "The ConfigMap '" + NOTIFICATION_CONFIG_MAP_NAME + "' is used for storing notification preferences and should not be used for any other purpose.  Other values may be discarded or overwritten if these preferences are saved."
+                  };
+                }
+              })
+
+              $scope.config = angular.copy(resource);
+              $scope.reset();
+            }, function (error) {
+              // If the map isn't found, we need to create it on save
+              if (error.status === 404) {
+                return;
+              }
+
+              var details = $filter('getErrorDetails')(error);
+              if (details) {
+                details = "Reason: " + details;
+              }
+              $scope.alerts['onlineNotificationPreferences'] = {
+                type: "error",
+                message: "Failed to read notification preferences for project " + $scope.projectName + ".",
+                details: details
+              };
+            });
+        }));
+    })
+    .config(function ($routeProvider) {
+      $routeProvider
+        .when('/project/:project/online/notifications', {
+          templateUrl: 'online/ui/custom-templates/online-notifications.html',
+          controller: 'OnlineNotificationController'
+        })
+    });
+
+  hawtioPluginLoader.addModule('onlineNotificationExtensions');
+})();

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "online-console-extensions",
+  "version": "3.9.0-alpha.0",
+  "dependencies": {},
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/openshift/online-console-extensions.git"
+  },
+  "devDependencies": {
+    "grunt": "^0.4.5",
+    "grunt-angular-templates": "^1.1.0"
+  }
+}

--- a/paid/ui/assets/extensions/templates.js
+++ b/paid/ui/assets/extensions/templates.js
@@ -1,0 +1,133 @@
+angular.module('openshiftOnlineConsoleTemplates', []).run(['$templateCache', function($templateCache) {
+  'use strict';
+
+  $templateCache.put('online/ui/custom-templates/about.html',
+    "<default-header class=\"top-header\"></default-header>\n" +
+    "<div class=\"wrap no-sidebar\">\n" +
+    "  <div class=\"sidebar-left collapse navbar-collapse navbar-collapse-2\">\n" +
+    "    <navbar-utility-mobile></navbar-utility-mobile>\n" +
+    "  </div>\n" +
+    "  <div class=\"middle surface-shaded\">\n" +
+    "    <!-- Middle section -->\n" +
+    "    <div class=\"middle-section\">\n" +
+    "      <div class=\"middle-container\">\n" +
+    "	<div class=\"middle-content\">\n" +
+    "	  <div class=\"container surface-shaded gutter-top\">\n" +
+    "	    <div class=\"row\">\n" +
+    "	      <div class=\"col-md-12\">\n" +
+    "		<div class=\"about\">\n" +
+    "		  <div class=\"row\">\n" +
+    "		    <div class=\"col-md-2 about-icon gutter-top hidden-sm hidden-xs\">\n" +
+    "		      <img src=\"images/openshift-logo.svg\" />\n" +
+    "		    </div>\n" +
+    "		    <div class=\"col-md-9\">\n" +
+    "		      <h1>Red Hat OpenShift <span class=\"about-reg\">&reg;</span></h1>\n" +
+    "		      <h2>About</h2>\n" +
+    "		      <p><a target=\"_blank\" href=\"https://openshift.com\">OpenShift</a> is Red Hat's Platform-as-a-Service (PaaS) that allows developers to quickly develop, host, and scale applications in a cloud environment.</p>\n" +
+    "\n" +
+    "		      <h2 id=\"version\">Version</h2>\n" +
+    "		      <dl class=\"dl-horizontal left\">\n" +
+    "			<dt>OpenShift Master:</dt>\n" +
+    "			<dd>{{version.master.openshift || 'unknown'}}</dd>\n" +
+    "			<dt>Kubernetes Master:</dt>\n" +
+    "			<dd>{{version.master.kubernetes || 'unknown'}}</dd>\n" +
+    "		      </dl>\n" +
+    "\n" +
+    "                      <h2>Registry</h2>\n" +
+    "		      <p>\n" +
+    "			You can push images to and pull images from the registry via:\n" +
+    "			<copy-to-clipboard display-wide=\"true\" clipboard-text=\"online_registry_url\" input-text=\"online_registry_url\" class=\"ng-isolate-scope\"></copy-to-clipboard>\n" +
+    "		      </p>\n" +
+    "		      \n" +
+    "		      <p>The <a target=\"_blank\" href=\"{{'welcome' | helpLink}}\">documentation</a> contains information and guides to help you learn about OpenShift and start exploring its features. From getting started with creating your first application, to trying out more advanced build and deployment techniques, it provides what you need to set up and manage your OpenShift environment as an application developer.</p>\n" +
+    "\n" +
+    "		      <p>With the OpenShift command line interface (CLI), you can create applications and manage OpenShift projects from a terminal. To get started using the CLI, visit <a href=\"command-line\">Command Line Tools</a>.\n" +
+    "		      </p>\n" +
+    "\n" +
+    "		    </div>\n" +
+    "		  </div>\n" +
+    "		</div>\n" +
+    "	      </div>\n" +
+    "	    </div>\n" +
+    "	  </div>\n" +
+    "	</div><!-- /middle-content -->\n" +
+    "      </div><!-- /middle-container -->\n" +
+    "    </div><!-- /middle-section -->\n" +
+    "  </div><!-- /middle -->\n" +
+    "</div><!-- /wrap -->\n"
+  );
+
+
+  $templateCache.put('online/ui/custom-templates/online-notifications.html',
+    "<project-header class=\"top-header\"></project-header>\n" +
+    "<project-page class=\"online-notifications\">\n" +
+    "  <!-- Middle section -->\n" +
+    "  <div class=\"middle-section\">\n" +
+    "    <div class=\"middle-container\">\n" +
+    "      <div class=\"middle-header\">\n" +
+    "        <div class=\"container-fluid\">\n" +
+    "          <div class=\"page-header\">\n" +
+    "            <h1>\n" +
+    "              Notifications\n" +
+    "              <span class=\"page-header-link page-header-bleed-right\">\n" +
+    "                <a ng-href=\"{{'notifications' | helpLink}}\" target=\"_blank\">\n" +
+    "                  Learn More <i class=\"fa fa-external-link\" aria-hidden=\"true\"></i>\n" +
+    "                </a>\n" +
+    "              </span>\n" +
+    "            </h1>\n" +
+    "          </div>\n" +
+    "        </div>\n" +
+    "      </div><!-- /middle-header-->\n" +
+    "      <div class=\"middle-content\">\n" +
+    "        <div class=\"container-fluid\">\n" +
+    "          <div class=\"row\">\n" +
+    "            <div class=\"col-md-10 col-lg-8\">\n" +
+    "              <p>Control which critical event email notifications to receive from OpenShift Online.</p>\n" +
+    "              <alerts alerts=\"alerts\"></alerts>\n" +
+    "              <p>Email notifications for project <strong>{{projectName}}</strong> will be sent to <strong>{{requester}}</strong></p>\n" +
+    "            </div>\n" +
+    "          </div>\n" +
+    "          <div class=\"row\">\n" +
+    "            <div class=\"col-md-10 col-lg-8\">\n" +
+    "              <form name=\"forms.notifications\">\n" +
+    "                <fieldset ng-disabled=\"disableInputs\">\n" +
+    "                  <div class=\"form-group\">\n" +
+    "                    <h4>Send notifications about critical events related to:</h4>\n" +
+    "                    <div class=\"checkbox\">\n" +
+    "                      <label>\n" +
+    "                        <input ng-model=\"updatedPrefs.deployments\" ng-true-value=\"'true'\" ng-false-value=\"'false'\" type=\"checkbox\" autocomplete=\"off\">\n" +
+    "                        Application deployments\n" +
+    "                      </label>\n" +
+    "                      <div style=\"padding-left: 20px\">Example: Requesting more replicas than your quota allows.</div>\n" +
+    "                    </div>\n" +
+    "                    <div class=\"checkbox\">\n" +
+    "                      <label>\n" +
+    "                        <input ng-model=\"updatedPrefs.builds\" ng-true-value=\"'true'\" ng-false-value=\"'false'\" type=\"checkbox\" autocomplete=\"off\">\n" +
+    "                        Builds\n" +
+    "                      </label>\n" +
+    "                      <div style=\"padding-left: 20px\">Example: An automatically-triggered build fails, no notifications sent for repeat failures.</div>\n" +
+    "                    </div>\n" +
+    "                    <div class=\"checkbox\">\n" +
+    "                      <label>\n" +
+    "                        <input ng-model=\"updatedPrefs.storage\" ng-true-value=\"'true'\" ng-false-value=\"'false'\" type=\"checkbox\" autocomplete=\"off\">\n" +
+    "                        Storage and persistent volumes\n" +
+    "                      </label>\n" +
+    "                      <div style=\"padding-left: 20px\">Example: Unable to find a volume that satisfies the constraints defined in your persistent volume claim (PVC).</div>\n" +
+    "                    </div>\n" +
+    "                  </div>\n" +
+    "                  <div class=\"button-group gutter-top gutter-bottom\">\n" +
+    "                    <button type=\"submit\" class=\"btn btn-default\" ng-click=\"save()\" ng-disabled=\"forms.notifications.$invalid || forms.notifications.$pristine || disableInputs\" value=\"\">Save</button>\n" +
+    "                    <a ng-if=\"!forms.notifications.$pristine\" href=\"\" ng-click=\"reset()\" class=\"mar-left-sm\" style=\"vertical-align: -2px\">Clear changes</a>\n" +
+    "                  </div>\n" +
+    "                </fieldset>\n" +
+    "              </form>\n" +
+    "            </div><!-- /col-* -->\n" +
+    "          </div>\n" +
+    "        </div>\n" +
+    "      </div><!-- /middle-content -->\n" +
+    "    </div><!-- /middle-container -->\n" +
+    "  </div><!-- /middle-section -->\n" +
+    "</project-page>\n"
+  );
+
+}]);

--- a/ui/assets/extensions/online-extensions.js
+++ b/ui/assets/extensions/online-extensions.js
@@ -68,11 +68,11 @@
    * Custom angular module
    */
   angular
-    .module('openshiftOnlineConsoleExtensions', ['openshiftConsole'])
+    .module('openshiftOnlineConsoleExtensions', ['openshiftConsole', 'openshiftOnlineConsoleTemplates'])
     .config(function($routeProvider) {
       $routeProvider
 	.when('/about', {
-	  templateUrl: 'extensions/about/about.html',
+	  templateUrl: 'online/ui/custom-templates/about.html',
 	  controller: 'AboutController'
 	});
     })


### PR DESCRIPTION
This adds a hack-build Gruntfile which will generate our custom templates (for About and Notifications) as Javascript to be served by Angular.

Ansible launchers will need to be updated to include `ui/assets/extensions/templates.js` before `online-extensions.js` in the `extensionScripts` field. This should properly include the html templates for our About and Notifications extensions. (@sallyom)