### PR TITLE
Ops manages python modules using yum

### DIFF
--- a/ansible/roles/oso_console_extensions/tasks/main.yml
+++ b/ansible/roles/oso_console_extensions/tasks/main.yml
@@ -6,8 +6,9 @@
   with_items: "{{ required_vars }}"
 
 # Install (docker-py) python package.
-- pip:
-    name: docker-py
+- yum:
+    name: python-docker-py
+    state: installed
 
 - import_tasks: uninstall.yml
   when: osce_uninstall | bool


### PR DESCRIPTION
To help keep our systems consistent, manage modules using yum.