### PR TITLE
remove build of custom-builder image

### DIFF
--- a/ansible/roles/oso_console_extensions/defaults/main.yml
+++ b/ansible/roles/oso_console_extensions/defaults/main.yml
@@ -30,6 +30,7 @@ required_vars:
   - osce_properties
 
 # This won't be necessary once the custom builder image is synced to aws-registry
+# Change this to whatever we name the builder image in aws-reg
 osce_builder_image: 'online-console-extensions-builder:latest'
 osce_builder_repo: 'https://github.com/sallyom/online-console-extensions.git'
 osce_builder_git_ref: 'ansible-template'

--- a/ansible/roles/oso_console_extensions/tasks/main.yml
+++ b/ansible/roles/oso_console_extensions/tasks/main.yml
@@ -5,40 +5,8 @@
   when: item not in vars
   with_items: "{{ required_vars }}"
 
-# Install (docker-py) python package.
-- yum:
-    name: python-docker-py
-    state: installed
-
 - import_tasks: uninstall.yml
   when: osce_uninstall | bool
-
-- debug: msg="Building {{ osce_builder_image}} builder image from {{ osce_builder_repo }} ref {{ osce_builder_git_ref }}"
-
-- name: 'Check for existence of repo {{ osce_builder_repo }}'
-  git:
-    repo: "{{ osce_builder_repo }}"
-    version: "{{ osce_builder_git_ref }}"
-    accept_hostkey: true
-    dest: /data/src/github.com/openshift/online-console-extensions
-    update: no
-  delegate_to: "{{ inventory_hostname }}"
-  failed_when: false
-  register: repo_exists
-
-- name: Fetch latest git {{ osce_builder_repo }}
-  git:
-    repo: "{{ osce_builder_repo }}"
-    version: "{{ osce_builder_git_ref }}"
-    accept_hostkey: true
-    dest: /data/src/github.com/openshift/online-console-extensions
-  delegate_to: "{{ inventory_hostname }}"
-  when: repo_exists.failed
-
-- name: Build console-extensions builder image
-  docker_image:
-     path: /data/src/github.com/openshift/online-console-extensions/s2i-custom-builder
-     name: "{{ osce_builder_image }}"
 
 - debug: msg="Deploying {{ osce_appname}} from {{ osce_git_repo }} ref {{ osce_git_ref }}"
 


### PR DESCRIPTION
@dak1n1 @damemi @abhgupta 
this PR depends on us hosting a custom-builder image in an accessible location.

To build: 
- git clone https://github.com/openshift/online-console-extensions.git
 - cd online-console-extensions/s2i-custom-builder
 - docker build -t [whatever we want to name the custom-builder in our registry] .    <-don't forget the '.'   :)   this image is ~350 MB
 - push the image to our registry

B4 we merge this, edit the 'osce_builder_image: [whatever we name it in our registry]'  in defaults/main.yml