### PR TITLE
more image-name fixes

### DIFF
--- a/ansible/roles/oso_console_extensions/defaults/main.yml
+++ b/ansible/roles/oso_console_extensions/defaults/main.yml
@@ -29,4 +29,4 @@ required_vars:
   - osce_scripts
   - osce_properties
 
-osce_builder_image: 'registry.reg-aws.openshift.com/openshift3/oso-console-extensions:latest'
+osce_builder_image: 'registry.reg-aws.openshift.com/openshift3/{{ osce_appname }}-builder:latest'

--- a/ansible/roles/oso_console_extensions/tasks/main.yml
+++ b/ansible/roles/oso_console_extensions/tasks/main.yml
@@ -19,13 +19,13 @@
   oc_obj:
     state: present
     namespace: "{{ osce_namespace }}"
-    name: online-console-extensions
+    name: "{{ osce_appname }}"
     kind: template
     files:
     - "{{ osce_template_path }}"
 
 - name: Apply template
-  shell: "oc process -n {{ osce_namespace }} online-console-extensions | oc apply -n {{ osce_namespace }} -f -"
+  shell: "oc process -n {{ osce_namespace }} {{ osce_appname }} | oc apply -n {{ osce_namespace }} -f -"
   # apply does not indicate if something changed today. Assume changed_when
   # false and rely on the template update as our best indicator if something
   # changed.
@@ -47,7 +47,7 @@
 - name: Start build if required
   oc_start_build_check:
     namespace: "{{ osce_namespace }}"
-    buildconfig: "online-console-extensions"
+    buildconfig: "{{ osce_appname }}"
     git_ref: "{{ git_sha1_results.after }}"
   register: start_build_out
 

--- a/ansible/roles/oso_console_extensions/templates/console-extensions-template.yml.j2
+++ b/ansible/roles/oso_console_extensions/templates/console-extensions-template.yml.j2
@@ -1,12 +1,12 @@
 apiVersion: v1
 kind: Template
 metadata:
-  name: online-console-extensions
+  name: "{{ osce_appname }}"
 
 parameters:
 - name: NAME
-  description: The name of the DeploymentConfig
-  value: online-console-extensions
+  description: The name of the console-extensions app
+  value: "{{ osce_appname }}"
 - name: GIT_REPO
   description: Git repository housing the code to build and deploy
   value: "https://github.com/openshift/online-console-extensions.git"


### PR DESCRIPTION
@dak1n1 
@damemi thanks for noticing we were using the same name for the builder-image as the imagestream.

Also, to make things more clear, I've replaced 'online-console-extensions' with 'osce_appname' , that is 'oso-console-extensions'