### PR TITLE
Fixing the console-extension route in free-int

### DIFF
--- a/ansible/roles/oso_console_extensions/defaults/main.yml
+++ b/ansible/roles/oso_console_extensions/defaults/main.yml
@@ -28,5 +28,6 @@ required_vars:
   - osce_stylesheets
   - osce_scripts
   - osce_properties
+  - osce_url
 
 osce_builder_image: 'registry.reg-aws.openshift.com/openshift3/{{ osce_appname }}-builder:latest'

--- a/ansible/roles/oso_console_extensions/tasks/main.yml
+++ b/ansible/roles/oso_console_extensions/tasks/main.yml
@@ -16,13 +16,7 @@
     dest: "{{ osce_template_path }}"
 
 - name: Create template
-  oc_obj:
-    state: present
-    namespace: "{{ osce_namespace }}"
-    name: "{{ osce_appname }}"
-    kind: template
-    files:
-    - "{{ osce_template_path }}"
+  command: "oc apply -f {{ osce_template_path }} -n {{ osce_namespace }}"
 
 - name: Apply template
   shell: "oc process -n {{ osce_namespace }} {{ osce_appname }} | oc apply -n {{ osce_namespace }} -f -"
@@ -52,3 +46,12 @@
   register: start_build_out
 
 - debug: var=start_build_out
+
+- name: Create edge route for console-extensions url
+  oc_route:
+    name: "{{ osce_appname }}"
+    namespace: "{{ osce_namespace }}"
+    service_name: "{{ osce_appname }}"
+    tls_termination: edge
+    port: 8080
+    host: "{{ osce_url }}"

--- a/ansible/roles/oso_console_extensions/templates/console-extensions-template.yml.j2
+++ b/ansible/roles/oso_console_extensions/templates/console-extensions-template.yml.j2
@@ -93,27 +93,6 @@ objects:
           - containerPort: 8080
             protocol: TCP
 
-- apiVersion: v1
-  kind: Route
-  metadata:
-    annotations:
-      openshift.io/host.generated: "true"
-    creationTimestamp: null
-    labels:
-      app: ${NAME}
-    name: ${NAME}
-  spec:
-    port:
-      targetPort: 8443-tcp
-    to:
-      kind: Service
-      name: ${NAME}
-      weight: 100
-    tls:
-      termination: passthrough
-      insecureEdgeTerminationPolicy: Redirect
-    wildcardPolicy: None
-
 # A service to expose the ui-extensions server
 - apiVersion: v1
   kind: Service
@@ -127,5 +106,9 @@ objects:
       port: 8443
       protocol: TCP
       targetPort: 8443
+    - name: 8080-tcp
+      port: 8080
+      protocol: TCP
+      targetPort: 8080
     selector:
       app: ${NAME}


### PR DESCRIPTION
* Use service-signer cert for route
* Use oc_route for idempotent reencrypt route creation with Ops certs

This also contains changes from https://github.com/openshift/online-console-extensions/pull/17