### PR TITLE
Use rhel httpd image for custom builder

### DIFF
--- a/s2i-custom-builder/Dockerfile
+++ b/s2i-custom-builder/Dockerfile
@@ -1,2 +1,2 @@
-FROM centos/httpd-24-centos7
+FROM rhscl/httpd-24-rhel7
 COPY assemble /usr/libexec/s2i/assemble


### PR DESCRIPTION
Tested in a devenv with no apparent issues changing from centos to rhel image