### PR TITLE
Add damemi, sallyom, and dak1n1 to approvers

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -12,4 +12,7 @@ approvers:
   - abhgupta
   - markturansky
   - tiwillia
+  - damemi
+  - sallyom
+  - dak1n1
 


### PR DESCRIPTION
Adding me and @sallyom as approvers. Currently the list of approvers is limited in relevance to the work specific to this repo. This will allow us to `/lgtm` or `/approve` on PRs, triggering an auto merge from the CI-bot if checks pass (see https://github.com/kubernetes/community/blob/master/contributors/guide/owners.md#the-code-review-process)