### PR TITLE
ansible: add dedicated target, cluster tier

### DIFF
--- a/ansible/roles/oso_console_extensions/defaults/main.yml
+++ b/ansible/roles/oso_console_extensions/defaults/main.yml
@@ -1,11 +1,12 @@
 osce_appname: 'oso-console-extensions'
 
-# osce_target will be one of 'free|paid'.
+# osce_target will be one of 'free|paid|dedicated'.
 # osod_cluster_tier ==> osce_target
 #           starter ==> free
 #               pro ==> paid 
 #             dsaas ==> free
 #              osio ==> free
+#         dedicated ==> dedicated
 
 # WARNING: Keep these in sync with the defaults in the template.  We want the
 # template to be independently usable so default must be defined in both.


### PR DESCRIPTION
@dak1n1 
I think this will be a new required variable in a dedicated cluster: 'osod_cluster_tier: dedicated' 
and also will be required in dedicated clusters:
osce_scripts
osce_sylesheets
osce_properties



