### PR TITLE
Add free and paid online-extensions.js files for custom quota messages

### DIFF
--- a/free/ui/assets/extensions/free-online-extensions.js
+++ b/free/ui/assets/extensions/free-online-extensions.js
@@ -1,0 +1,10 @@
+/*
+ * Online extensions specific to free tier
+ */
+
+window.OPENSHIFT_CONSTANTS.QUOTA_NOTIFICATION_MESSAGE = {
+  "memory": "Upgrade to <a href=\""+window.OPENSHIFT_EXTENSION_PROPERTIES.account_url+"/register/plan\">OpenShift Online Pro</a> for access to additional resources",
+  "cpu": "Upgrade to <a href=\""+window.OPENSHIFT_EXTENSION_PROPERTIES.account_url+"/register/plan\">OpenShift Online Pro</a> for access to additional resources",
+  "persistentvolumeclaims": "Upgrade to <a href=\""+window.OPENSHIFT_EXTENSION_PROPERTIES.account_url+"/register/plan\">OpenShift Online Pro</a> for access to additional resources",
+  "requests.storage": "Upgrade to <a href=\""+window.OPENSHIFT_EXTENSION_PROPERTIES.account_url+"/register/plan\">OpenShift Online Pro</a> for access to additional resources"
+}

--- a/paid/ui/assets/extensions/paid-online-extensions.js
+++ b/paid/ui/assets/extensions/paid-online-extensions.js
@@ -1,0 +1,10 @@
+/*
+ * Online extensions specific to pro tier
+ */
+
+window.OPENSHIFT_CONSTANTS.QUOTA_NOTIFICATION_MESSAGE = {
+  "memory": "<a href=\""+window.OPENSHIFT_EXTENSION_PROPERTIES.account_url+"\">Manage your subscription</a> to add additional resources",
+  "cpu": "<a href=\""+window.OPENSHIFT_EXTENSION_PROPERTIES.account_url+"\">Manage your subscription</a> to add additional resources",
+  "persistentvolumeclaims": "<a href=\""+window.OPENSHIFT_EXTENSION_PROPERTIES.account_url+"\">Manage your subscription</a> to add additional resources",
+  "requests.storage": "<a href=\""+window.OPENSHIFT_EXTENSION_PROPERTIES.account_url+"\">Manage your subscription</a> to add additional resources"
+}


### PR DESCRIPTION
Card: https://trello.com/c/BkleYWax/958-2-pro-provide-custom-messages-for-hitting-quotas

Note that adding these two files will require them to be added to the webconsole configmap under `scriptURLs` in order to take effect, and only on their specific clusters

Screenshot of paid cluster:
![quota-2](https://user-images.githubusercontent.com/1839101/42774089-d2be099e-88fe-11e8-81e3-442c6551a90c.png)

See this pr for reference: https://github.com/openshift/origin-web-console/pull/2116
(Available quota messages: https://github.com/openshift/origin-web-console/blob/master/app/scripts/services/quota.js#L115)