### PR TITLE
Remove PVC quota message from paid and storage message from free

### DIFF
--- a/free/ui/assets/extensions/free-online-extensions.js
+++ b/free/ui/assets/extensions/free-online-extensions.js
@@ -5,6 +5,5 @@
 window.OPENSHIFT_CONSTANTS.QUOTA_NOTIFICATION_MESSAGE = {
   "memory": "Upgrade to <a href=\""+window.OPENSHIFT_EXTENSION_PROPERTIES.account_url+"/register/plan\">OpenShift Online Pro</a> for access to additional resources",
   "cpu": "Upgrade to <a href=\""+window.OPENSHIFT_EXTENSION_PROPERTIES.account_url+"/register/plan\">OpenShift Online Pro</a> for access to additional resources",
-  "persistentvolumeclaims": "Upgrade to <a href=\""+window.OPENSHIFT_EXTENSION_PROPERTIES.account_url+"/register/plan\">OpenShift Online Pro</a> for access to additional resources",
-  "requests.storage": "Upgrade to <a href=\""+window.OPENSHIFT_EXTENSION_PROPERTIES.account_url+"/register/plan\">OpenShift Online Pro</a> for access to additional resources"
+  "persistentvolumeclaims": "Upgrade to <a href=\""+window.OPENSHIFT_EXTENSION_PROPERTIES.account_url+"/register/plan\">OpenShift Online Pro</a> for access to additional resources"
 }

--- a/paid/ui/assets/extensions/paid-online-extensions.js
+++ b/paid/ui/assets/extensions/paid-online-extensions.js
@@ -5,6 +5,5 @@
 window.OPENSHIFT_CONSTANTS.QUOTA_NOTIFICATION_MESSAGE = {
   "memory": "<a href=\""+window.OPENSHIFT_EXTENSION_PROPERTIES.account_url+"\">Manage your subscription</a> to add additional resources",
   "cpu": "<a href=\""+window.OPENSHIFT_EXTENSION_PROPERTIES.account_url+"\">Manage your subscription</a> to add additional resources",
-  "persistentvolumeclaims": "<a href=\""+window.OPENSHIFT_EXTENSION_PROPERTIES.account_url+"\">Manage your subscription</a> to add additional resources",
   "requests.storage": "<a href=\""+window.OPENSHIFT_EXTENSION_PROPERTIES.account_url+"\">Manage your subscription</a> to add additional resources"
 }


### PR DESCRIPTION
Based on feedback from QE, there is no need for a PVC quota message in paid tier, nor a storage quota message in free tier since these quotas do not exist on these tiers.